### PR TITLE
Replace `go get` with `go install`

### DIFF
--- a/dockerfiles/tests/Dockerfile
+++ b/dockerfiles/tests/Dockerfile
@@ -33,7 +33,7 @@ ENV GOROOT=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 ENV GO111MODULE=on
-RUN go get github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
+RUN go install github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
 ENV GOFLAGS=-mod=vendor
 
 RUN sed -i 's/VFS/MEM/' /start.sh


### PR DESCRIPTION
[#183154297]

Newest versions of go disallow the usage
of `go get` to install packages globally
and requires you to migrate to `go install`