### PR TITLE
Config file template for MapFS

### DIFF
--- a/jobs/mapfs/spec
+++ b/jobs/mapfs/spec
@@ -3,6 +3,7 @@ name: mapfs
 
 templates:
   install.erb: bin/pre-start
+  mapfs.yml.erb: config/mapfs.yml
 
 packages:
 - mapfs

--- a/jobs/mapfs/templates/mapfs.yml.erb
+++ b/jobs/mapfs/templates/mapfs.yml.erb
@@ -1,0 +1,5 @@
+# debug: false # Enable go-fuse debug log, outputs to /var/vcap/sys/log/mapfs/mapfs.$$.log
+# single_threaded: false # Single threaded operation of go-fuse
+# cpu_profile: <path> # Outputs a CPU profile to the specified path
+# mem_profile: <path> # Outputs a memory profile to the specified path whenever the process receives a SIGUSR1
+# soft_mem_limit: <bytes> # Equivalent to setting the GOMEMLIMIT environment variable


### PR DESCRIPTION
MapFS has a new config file which is optional, but it's helpful to have an empty template to guide folks using it.