### PR TITLE
fix bug introduced in 964e4a7

### DIFF
--- a/jobs/mapfs/templates/install.erb
+++ b/jobs/mapfs/templates/install.erb
@@ -8,31 +8,33 @@ function prepend_rfc3339_datetime() {
 }
 
 function main() {
+  # [[ -f .../ ]] does resolve links.
+  # e.g.
+  # ln -s /test/non-existing-target symlink-to-nonexisting
+  # [[ -f ./symlink-to-nonexisting ]] => 1
+  # touch /test/existing-target
+  # ln -s /test/existing-target symlink-to-existing
+  # [[ -f ./symlink-to-existing ]] => 0
+
+  # /var/vcap/packages/mapfs-fuse itself is a symlink
+  # e.g:
+  # /var/vcap/packages/mapfs-fuse -> /var/vcap/data/packages/mapfs-fuse/7b0feec064cdabced95809f129c7ba1495afeede
+  # We will need to always overwrite the symlinks, because in a scenario where this release gets updated but the 
+  # VM stays the same, we need to relink because the target of `/var/vcap/packages/mapfs-fuse` changed.
 
   if [[ ! -f /sbin/mount.fuse3 ]]; then
     echo "symlinking fuse mounthelper binary to /sbin"
-    ln -s /var/vcap/packages/mapfs-fuse/sbin/mount.fuse3 /sbin/mount.fuse3
+    ln -fs "$( readlink -f /var/vcap/packages/mapfs-fuse/sbin/mount.fuse3 )" /sbin/mount.fuse3
   fi
   if [[ ! -f /bin/fusermount ]]; then
     echo "symlinking fusermount3 to /bin/fusermount"
-    ln -s /var/vcap/packages/mapfs-fuse/bin/fusermount3 /bin/fusermount
+    ln -fs "$( readlink -f /var/vcap/packages/mapfs-fuse/bin/fusermount3 )" /bin/fusermount
   fi
-  for FULL_PATH in $( find /var/vcap/packages/mapfs-fuse/lib/x86_64-linux-gnu/ -name  "*.so*" ); do 
  
-    if [[ -L $FULL_PATH ]]; then
-      RESOLVED_PATH=$(readlink -f $FULL_PATH)
-      LINK_NAME=$(basename $FULL_PATH )
-      if [[ ! -f /lib/$LINK_NAME ]]; then
-        echo "creating a symlink from /lib/$LINK_NAME to $RESOLVED_PATH"
-        ln -s $RESOLVED_PATH /lib/$LINK_NAME
-      fi
-    else
-      if [ ! -f /lib/${TARGET_NAME} ]]; then
-        TARGET_NAME=$(basename $FULL_PATH)
-        echo "symlinking shared lib ${FULL_PATH} to /lib/$TARGET_NAME"
-        ln -s $FULL_PATH /lib/${TARGET_NAME}
-      fi
-    fi
+  for FULL_PATH in $( find /var/vcap/packages/mapfs-fuse/lib/x86_64-linux-gnu/ -name  "*.so*" ); do 
+    TARGET_PATH="$( readlink -f $FULL_PATH )"
+    LINK_NAME="$( basename $FULL_PATH )"
+    ln -sf "$TARGET_PATH" "/lib/$LINK_NAME"
   done
 
   modprobe fuse || true


### PR DESCRIPTION
[ #186969827 ]

The release versions 1.2.53 && 1.2.52 are currently broken in some deploy scenarios.

what works:

- deploying a fresh VM ( e.g. on stemcell upgrade, anything that would recreate the VM)

what breaks:
- upgrading an existing VM that already ran the pre-start script from this release without changing the stemcell

when an existing VM tries to run this pre-start script again, it will fail because of a missing `[` in the check for the existence of the shared libs for lib-fuse.

Unfortunately none of the CI that tests this release is testing for this particular setup. All upgrade tests also include a change to the stemcell and thus this issue has gone unnoticed.