### PR TITLE
Validate against integer overflows in mapfs's Chown() call

### DIFF
--- a/src/code.cloudfoundry.org/mapfs/main.go
+++ b/src/code.cloudfoundry.org/mapfs/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"log"
+	"math"
 	"os"
 	"os/signal"
 	"path"
@@ -16,6 +16,8 @@ import (
 	"runtime/pprof"
 	"syscall"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"code.cloudfoundry.org/goshims/syscallshim"
 	"code.cloudfoundry.org/mapfs/mapfs"
@@ -38,6 +40,11 @@ func main() {
 	if flag.NArg() < 2 || *uid <= 0 || *gid <= 0 {
 		fmt.Printf("usage: %s -uid UID -gid GID [-fsname FSNAME] [-auto_cache] [-debug] MOUNTPOINT ORIGINAL\n", path.Base(os.Args[0]))
 		fmt.Println("UID and GID must be > 0")
+		os.Exit(2)
+	}
+	if *uid > math.MaxUint32 || *gid > math.MaxUint32 {
+		fmt.Printf("usage: %s -uid UID -gid GID [-fsname FSNAME] [-auto_cache] [-debug] MOUNTPOINT ORIGINAL\n", path.Base(os.Args[0]))
+		fmt.Printf("UID and GID must be <= %d\n", math.MaxUint32)
 		os.Exit(2)
 	}
 	if *autoCache {
@@ -66,7 +73,7 @@ func main() {
 
 	orig := flag.Arg(1)
 	loopbackfs := pathfs.NewLoopbackFileSystem(orig)
-	finalFs := mapfs.NewMapFileSystem(*uid, *gid, loopbackfs, orig, &syscallshim.SyscallShim{})
+	finalFs := mapfs.NewMapFileSystem(uint32(*uid), uint32(*gid), loopbackfs, orig, &syscallshim.SyscallShim{})
 
 	opts := &nodefs.Options{
 		NegativeTimeout: time.Second,

--- a/src/code.cloudfoundry.org/mapfs/mapfs/mapfs.go
+++ b/src/code.cloudfoundry.org/mapfs/mapfs/mapfs.go
@@ -21,13 +21,13 @@ const (
 
 type mapFileSystem struct {
 	pathfs.FileSystem
-	uid, gid      int64
+	uid, gid      uint32
 	syscall       syscallshim.Syscall
 	root          string
 	disableXAttrs bool
 }
 
-func NewMapFileSystem(uid, gid int64, fs pathfs.FileSystem, root string, sys syscallshim.Syscall) pathfs.FileSystem {
+func NewMapFileSystem(uid, gid uint32, fs pathfs.FileSystem, root string, sys syscallshim.Syscall) pathfs.FileSystem {
 	// Make sure the Root path is absolute to avoid problems when the
 	// application changes working directory.
 	root, err := filepath.Abs(root)
@@ -78,10 +78,10 @@ func (fs *mapFileSystem) GetAttr(name string, context *fuse.Context) (a *fuse.At
 	a, code = fs.FileSystem.GetAttr(name, context)
 
 	if a != nil {
-		if int64(a.Uid) == fs.uid {
+		if a.Uid == fs.uid {
 			a.Uid = context.Uid
 		}
-		if int64(a.Gid) == fs.gid {
+		if a.Gid == fs.gid {
 			a.Gid = context.Gid
 		}
 	}

--- a/src/code.cloudfoundry.org/mapfs/mapfs/mapfs_test.go
+++ b/src/code.cloudfoundry.org/mapfs/mapfs/mapfs_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("mapfs", func() {
 	var (
 		mapFS    pathfs.FileSystem
-		uid, gid int64
+		uid, gid uint32
 
 		fakeFS      *mapfs_fakes.FakeFileSystem
 		fakeSyscall *syscall_fake.FakeSyscall


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
FUSE uses uint32 for UID/GID, so downcast the input to mapfs on startup, rather than during a Chown, and check that it's not greater than maxuint32, to avoid integer overflows


Backward Compatibility
---------------
Breaking Change?

Maybe? Previously if a uid/gid > MaxUint32 was specified, and chown was called, it would wrap around and provide an incorrect (but repeatable) number. AFIACT no UID/GIDs would be 64bit on linux though. 